### PR TITLE
add policy config into v1 share file spec and backfill for legacy, add loading spinners for encrypt and decrypt operations

### DIFF
--- a/llm/context/igloo-core-readme.md
+++ b/llm/context/igloo-core-readme.md
@@ -635,6 +635,8 @@ if (!await canReceiveFromPeer(node, 'npub1example...')) {
 }
 ```
 
+> Desktop Igloo persists policy overrides alongside each share. Share files written with version 1 now include a `policy` object recording the defaults (`allowSend`, `allowReceive`) plus optional peer-specific overrides keyed by normalized pubkeys. Legacy share files (missing a `policy` field or marked with a version less than 1) should be treated as allowing inbound and outbound traffic for every peer until the signer upgrades and saves the file.
+
 ## Validation
 
 The library provides validation for all credential types and formats.

--- a/llm/context/share-file-version1.md
+++ b/llm/context/share-file-version1.md
@@ -16,6 +16,7 @@ Each share is stored as JSON. The following fields are recognised:
 | `version` | number | ✓ | File format version. `1` corresponds to the parameters below. |
 | `savedAt` | string | — | ISO-8601 timestamp of persistence. |
 | `metadata` | object | — | Optional contextual details (binder serial, etc.). |
+| `policy` | object | — | Directional policy defaults and overrides for peers. See below. |
 
 > Producers **MUST** include `"version": 1` when writing new share files. Consumers **MUST** treat files without a `version` field as legacy (pre-v1) and fall back to the legacy behaviour (PBKDF2 with 32 iterations).
 
@@ -34,9 +35,31 @@ Additional properties MAY be present for forward compatibility.
   "savedAt": "2025-10-01T12:34:56.000Z",
   "metadata": {
     "binder_sn": "abc123"
+  },
+  "policy": {
+    "defaults": {
+      "allowSend": true,
+      "allowReceive": true
+    },
+    "peers": {
+      "npub1example...": {
+        "allowSend": true,
+        "allowReceive": false,
+        "updatedAt": "2025-10-02T08:15:30.000Z"
+      }
+    },
+    "updatedAt": "2025-10-02T08:15:30.000Z"
   }
 }
 ```
+
+### Policy Field
+
+- `defaults` records the baseline behaviour (inbound/outbound) and MUST default to allowing both directions.
+- `peers` is an optional map keyed by normalized (lowercase) pubkeys; entries only appear when the signer overrides the defaults for that peer.
+- `updatedAt` is an ISO-8601 timestamp refreshed whenever the signer persists policy updates.
+
+> Consumers MUST treat missing `policy` objects (or files with `version < 1`) as "allow both directions" for every peer and SHOULD only create the `policy` field when a share is upgraded to version 1 or later.
 
 ## Key Derivation
 

--- a/llm/context/share-file-version1.md
+++ b/llm/context/share-file-version1.md
@@ -42,7 +42,7 @@ Additional properties MAY be present for forward compatibility.
       "allowReceive": true
     },
     "peers": {
-      "npub1example...": {
+      "88a71d3e9f3ac066793a717fe1d329e77107de3bfae3d878014949daf07895c7": {
         "allowSend": true,
         "allowReceive": false,
         "updatedAt": "2025-10-02T08:15:30.000Z"

--- a/src/__tests__/components/Signer.test.tsx
+++ b/src/__tests__/components/Signer.test.tsx
@@ -11,6 +11,8 @@ jest.mock('@frostr/igloo-core', () => ({
   validateGroup: jest.fn(),
   decodeShare: jest.fn(),
   decodeGroup: jest.fn(),
+  setNodePolicies: jest.fn().mockResolvedValue([]),
+  normalizePubkey: jest.fn((value: string) => value?.toLowerCase?.() ?? value),
 }));
 
 // Get references to the mocked functions with proper typing

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -12,6 +12,7 @@ import { Tooltip } from "@/components/ui/tooltip"
 import { PageLayout } from "@/components/ui/page-layout"
 import { AppHeader } from "@/components/ui/app-header"
 import { ContentCard } from "@/components/ui/content-card"
+import type { IglooShare } from '@/lib/clientShareManager';
 
 interface KeysetData {
   groupCredential: string;
@@ -20,9 +21,9 @@ interface KeysetData {
 }
 
 interface SignerData {
-  share: string;
+  decryptedShare: string;
   groupCredential: string;
-  name?: string;
+  shareRecord: IglooShare;
   threshold?: number;
   totalShares?: number;
 }
@@ -53,8 +54,12 @@ const App: React.FC = () => {
     setShowingCreate(false);
   };
 
-  const handleShareLoaded = (share: string, groupCredential: string, shareName: string) => {
-    setSignerData({ share, groupCredential, name: shareName });
+  const handleShareLoaded = ({ decryptedShare, groupCredential, shareRecord }: {
+    decryptedShare: string;
+    groupCredential: string;
+    shareRecord: IglooShare;
+  }) => {
+    setSignerData({ decryptedShare, groupCredential, shareRecord });
     // Ensure we're on the signer tab when a share is loaded
     const signerTab = document.querySelector('[data-state="active"][value="signer"]');
     if (!signerTab) {
@@ -202,7 +207,7 @@ const App: React.FC = () => {
             
             <TabsContent value="recover" className="border border-purple-900/30 rounded-lg p-4">
               <Recover 
-                initialShare={signerData?.share} 
+                initialShare={signerData?.decryptedShare} 
                 initialGroupCredential={signerData?.groupCredential}
                 defaultThreshold={signerData?.threshold}
                 defaultTotalShares={signerData?.totalShares}

--- a/src/components/Keyset.tsx
+++ b/src/components/Keyset.tsx
@@ -64,7 +64,14 @@ const Keyset: React.FC<KeysetProps> = ({ groupCredential, shareCredentials, name
       salt,
       groupCredential,
       version: CURRENT_SHARE_VERSION,
-      savedAt: new Date().toISOString()
+      savedAt: new Date().toISOString(),
+      policy: {
+        defaults: {
+          allowSend: true,
+          allowReceive: true
+        },
+        updatedAt: new Date().toISOString()
+      }
     };
 
     // Save the share

--- a/src/components/LoadShare.tsx
+++ b/src/components/LoadShare.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { 
-  derive_secret, 
+  derive_secret_async, 
   decrypt_payload,
   PBKDF2_ITERATIONS_DEFAULT,
   PBKDF2_ITERATIONS_LEGACY,
@@ -9,6 +9,8 @@ import {
 } from '@/lib/encryption';
 import { InputWithValidation } from '@/components/ui/input-with-validation';
 import { Button } from '@/components/ui/button';
+import { Loader2 } from 'lucide-react';
+import type { SharePolicy } from '@/types';
 
 interface LoadShareProps {
   share: {
@@ -18,6 +20,7 @@ interface LoadShareProps {
     salt: string;
     groupCredential: string;
     version?: number;
+    policy?: SharePolicy;
   };
   onLoad?: (decryptedShare: string, groupCredential: string) => void;
   onCancel?: () => void;
@@ -63,7 +66,9 @@ const LoadShare: React.FC<LoadShareProps> = ({ share, onLoad, onCancel }) => {
       })();
 
       // Derive key from password and stored salt
-      const secret = derive_secret(password, share.salt, targetIterations);
+      await new Promise<void>(resolve => setTimeout(resolve, 0));
+
+      const secret = await derive_secret_async(password, share.salt, targetIterations);
       
       // Decrypt the share
       const decryptedShare = decrypt_payload(secret, share.encryptedShare);
@@ -92,7 +97,13 @@ const LoadShare: React.FC<LoadShareProps> = ({ share, onLoad, onCancel }) => {
   };
 
   return (
-    <div className="bg-gray-900 border border-blue-900/50 rounded-lg p-6 shadow-xl backdrop-blur-sm">
+    <div className="relative bg-gray-900 border border-blue-900/50 rounded-lg p-6 shadow-xl backdrop-blur-sm">
+      {isSubmitting && (
+        <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 rounded-lg bg-gray-950/70 backdrop-blur-sm">
+          <Loader2 className="h-8 w-8 animate-spin text-blue-300" />
+          <span className="text-sm font-medium text-blue-200">Decrypting share…</span>
+        </div>
+      )}
       <h2 className="text-xl font-semibold text-blue-300 mb-4">
         Load Share {share.name && <span className="text-blue-400">({share.name})</span>}
       </h2>

--- a/src/components/ShareList.tsx
+++ b/src/components/ShareList.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { clientShareManager, IglooShare } from '@/lib/clientShareManager';
+import type { SharePolicy } from '@/types';
 import { decodeGroup, decodeShare } from '@frostr/igloo-core';
 import { FolderOpen, Trash2, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -9,8 +10,15 @@ import { Tooltip } from '@/components/ui/tooltip';
 import LoadShare from './LoadShare';
 import ConfirmModal from '@/components/ui/ConfirmModal';
 
+interface LoadedSharePayload {
+  decryptedShare: string;
+  groupCredential: string;
+  shareRecord: IglooShare;
+  policy?: SharePolicy;
+}
+
 interface ShareListProps {
-  onShareLoaded?: (share: string, groupCredential: string, shareName: string) => void;
+  onShareLoaded?: (payload: LoadedSharePayload) => void;
   onNewKeyset?: () => void;
 }
 
@@ -91,7 +99,12 @@ const ShareList: React.FC<ShareListProps> = ({ onShareLoaded, onNewKeyset }) => 
 
   const handleLoadComplete = (decryptedShare: string, groupCredential: string) => {
     if (onShareLoaded && loadingShare) {
-      onShareLoaded(decryptedShare, groupCredential, loadingShare.name);
+      onShareLoaded({
+        decryptedShare,
+        groupCredential,
+        shareRecord: loadingShare,
+        policy: loadingShare.policy
+      });
     }
     setLoadingShare(null);
   };

--- a/src/lib/encryption.ts
+++ b/src/lib/encryption.ts
@@ -1,7 +1,7 @@
 import { Buff }   from '@cmdcode/buff'
 import { gcm }    from '@noble/ciphers/aes'
 import { sha256 } from '@noble/hashes/sha256'
-import { pbkdf2 } from '@noble/hashes/pbkdf2'
+import { pbkdf2, pbkdf2Async } from '@noble/hashes/pbkdf2'
 
 export const PBKDF2_ITERATIONS_LEGACY = 32;
 export const PBKDF2_ITERATIONS_V1 = 600_000;
@@ -19,6 +19,57 @@ export function derive_secret (
   const options    = { c: iterations, dkLen: PBKDF2_KEY_LENGTH }
   const secret     = pbkdf2(sha256, pass_bytes, salt_bytes, options)
   return new Buff(secret).hex
+}
+
+export async function derive_secret_async (
+  password  : string,
+  rand_salt : string,
+  iterations = PBKDF2_ITERATIONS_DEFAULT
+) {
+  const saltBuff = Buff.hex(rand_salt, 32);
+  const saltBytes = new Uint8Array(saltBuff as ArrayLike<number>);
+
+  const passwordBuff = Buff.str(password);
+  const passwordDigest = (passwordBuff as { digest?: Uint8Array }).digest;
+  const passwordBytes = new Uint8Array(passwordDigest ?? passwordBuff);
+
+  const shouldUseSubtle =
+    typeof window !== 'undefined' &&
+    typeof window.crypto !== 'undefined' &&
+    typeof window.crypto.subtle !== 'undefined' &&
+    typeof Uint8Array !== 'undefined';
+
+  if (shouldUseSubtle) {
+    try {
+      const keyMaterial = await window.crypto.subtle.importKey(
+        'raw',
+        passwordBytes,
+        'PBKDF2',
+        false,
+        ['deriveBits']
+      );
+
+      const derivedBits = await window.crypto.subtle.deriveBits(
+        {
+          name: 'PBKDF2',
+          salt: saltBytes,
+          iterations,
+          hash: 'SHA-256'
+        },
+        keyMaterial,
+        PBKDF2_KEY_LENGTH * 8
+      );
+
+      return new Buff(new Uint8Array(derivedBits)).hex;
+    } catch (error) {
+      console.warn('SubtleCrypto PBKDF2 failed, falling back to JS implementation', error);
+      // Fall through to pbkdf2Async fallback below
+    }
+  }
+
+  const options   = { c: iterations, dkLen: PBKDF2_KEY_LENGTH };
+  const secret    = await pbkdf2Async(sha256, passwordBytes, saltBytes, options);
+  return new Buff(secret).hex;
 }
 
 export function encrypt_payload (

--- a/src/lib/shareManager.ts
+++ b/src/lib/shareManager.ts
@@ -18,6 +18,18 @@ interface IglooShare {
   lastUsed?: string;
   savedAt?: string;
   metadata?: Record<string, unknown>;
+  policy?: {
+    defaults: {
+      allowSend: boolean;
+      allowReceive: boolean;
+    };
+    peers?: Record<string, {
+      allowSend: boolean;
+      allowReceive: boolean;
+      updatedAt?: string;
+    }>;
+    updatedAt?: string;
+  };
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,18 @@ export interface IglooShareMetadata {
   [key: string]: string | number | boolean | null | undefined;
 }
 
+export interface SharePolicyEntry {
+  allowSend: boolean;
+  allowReceive: boolean;
+  updatedAt?: string;
+}
+
+export interface SharePolicy {
+  defaults: SharePolicyEntry;
+  peers?: Record<string, SharePolicyEntry>;
+  updatedAt?: string;
+}
+
 export interface IglooShare {
   id: string;
   name: string;
@@ -39,6 +51,7 @@ export interface IglooShare {
   savedAt?: string;
   shareCredential?: string;
   metadata?: IglooShareMetadata;
+  policy?: SharePolicy;
 }
 
 // Bifrost types (from @frostr/bifrost)
@@ -123,12 +136,24 @@ export interface SignerHandle {
   stopSigner: () => Promise<void>;
 }
 
+export interface SignerInitialData {
+  decryptedShare: string;
+  groupCredential: string;
+  shareRecord?: IglooShare;
+  threshold?: number;
+  totalShares?: number;
+  /**
+   * @deprecated Backward-compatible alias for decryptedShare
+   */
+  share?: string;
+  /**
+   * @deprecated Backward-compatible alias for shareRecord.name
+   */
+  name?: string;
+}
+
 export interface SignerProps {
-  initialData?: {
-    share: string;
-    groupCredential: string;
-    name?: string;
-  } | null;
+  initialData?: SignerInitialData | null;
 }
 
 // Keyset types


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Manage per‑peer send/receive policies for shares via the UI; policies persist and auto‑apply on connect.
  - Signer and peer views are policy‑aware, reflecting per‑peer overrides and defaults.
  - Saved shares include policy metadata and timestamps.
  - Encryption/decryption is more responsive using asynchronous key derivation; loading overlays and spinners show progress and improve accessibility.

- Documentation
  - Updated share schema and desktop docs covering policy persistence, defaults, peer overrides, and versioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->